### PR TITLE
Setting metrics interval seconds by `round_interval` configuration

### DIFF
--- a/lib/HRForecast/Data.pm
+++ b/lib/HRForecast/Data.pm
@@ -33,6 +33,10 @@ sub dbh {
     );
 }
 
+sub round_interval {
+    HRForecast->config->{round_interval} || 3600;
+}
+
 sub inflate_row {
     my ($self, $row) = @_;
     $row->{created_at} = Time::Piece->from_mysql_datetime($row->{created_at});
@@ -115,7 +119,7 @@ sub update {
     }
     $dbh->commit;
 
-    my $fixed_timestamp = $timestamp - ($timestamp % 3600);
+    my $fixed_timestamp = $timestamp - ($timestamp % $self->round_interval);
     $dbh->query(
         'REPLACE data SET metrics_id = ?, datetime = ?, number = ?',
         $metrics->{id}, localtime($fixed_timestamp)->mysql_datetime, $number

--- a/lib/HRForecast/Web.pm
+++ b/lib/HRForecast/Web.pm
@@ -40,8 +40,8 @@ sub calc_term {
         $from = HTTP::Date::str2time($from);
         $to = HTTP::Date::str2time($to);
     }
-    $from = localtime($from - ($from % 3600));
-    $to = localtime($to - ($to % 3600));
+    $from = localtime($from - ($from % $self->data->round_interval));
+    $to = localtime($to - ($to % $self->data->round_interval));
     return ($from,$to);
 }
 


### PR DESCRIPTION
The metrics interval is hard-coded as 3600. I know, this is 'HR'forecast. 
But, I hope this intarval could be changed by config.

In this patch, we can set interval seconds by the config param
'round_interval'(default:3600).

If this patch is not match HRForecast's philosophy, please reject it.
