### PR TITLE
Wait loadGraphs until element has appeared in window

### DIFF
--- a/views/base.tx
+++ b/views/base.tx
@@ -84,7 +84,7 @@ body {
 <script type="text/javascript" src="<: $c.req.uri_for('/js/site.js') :>"></script>
 <script type="text/javascript">
 $(function(){
-  $('div.metrics-graph').each(loadGraphs);
+  $('div.metrics-graph').each(loadGraphsLater);
   $('form.hxrpost').each(setHxrpost);
   $('button.hxr_confirm_button').each(setHxrConfirmBtn);
   $('button#add-new-row').click(addNewRow);


### PR DESCRIPTION
Rendering graphs were very heavy when there are many graphs in same page.
When I added 350 graphs in same section, Google Chrome has crashed.

This pull request change to wait rendering until element has appeared in window.
