### PR TITLE
add css white-space:nowrap for left menu.

### DIFF
--- a/views/base.tx
+++ b/views/base.tx
@@ -30,6 +30,9 @@ body {
 .display-none {
   display: none;
 }
+#accordion li a {
+  white-space: nowrap;
+}
 </style>
 </head>
 <body>


### PR DESCRIPTION
When section_name is long, section_name in left menu includes a new-line.
I added white-space:nowrap in css for left menu.
