### PR TITLE
複合グラフで値が無い場合は0にする

### DIFF
--- a/lib/HRForecast/Web.pm
+++ b/lib/HRForecast/Web.pm
@@ -699,7 +699,7 @@ my $display_complex_csv =  sub {
 
         push @result, [
             $datetime,
-            map { exists $date_group{$key}->{$_} ? $date_group{$key}->{$_} : '' } @id
+            map { exists $date_group{$key}->{$_} ? $date_group{$key}->{$_} : 0 } @id
         ];
     }
 


### PR DESCRIPTION
複合グラフで、どれかのグラフの値が無い場合はその値を0にしました。
plotしているタイミングがずれていてもグラフが崩れないようになります。

変更前
![complex_before](https://cloud.githubusercontent.com/assets/100908/12007241/ea4bea8a-ac3e-11e5-9334-141c7f059bed.png)

変更後
![complex_after](https://cloud.githubusercontent.com/assets/100908/12007242/ea4d42cc-ac3e-11e5-83ab-cba362265d5b.png)
